### PR TITLE
Add namespace to support AGP8+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,4 +43,6 @@ android {
     defaultConfig {
         minSdkVersion 16
     }
+
+    namespace "com.MAHAulia.device_imei"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.vai.device_imei">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.READ_PRIVILEGED_PHONE_STATE" />
 </manifest>


### PR DESCRIPTION
When i tried to build my app using Android Gradle Plugin 8+. I got this error,

```
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.

Recommendation: remove package="com.vai.device_imei" from the source AndroidManifest.xml: {project path}\android\src\main\AndroidManifest.xml.
```

This is because Android Gradle Plugin 8.0+ required [namespace in Module-level script](https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl). So i removed the package from AndroidManifest.xml and added the new namespace into the build.gradle instead.

I also removed package attributes in AndroidManifest to prevent 
```
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported. 
```
error during build phase. Feel free to edit your own namespaces before updating your package in pub.dev.

Tested on my app using OPPO Reno 5 Pro (API 33) and Android API 34 emulator.